### PR TITLE
Redo metric writes to influxdb

### DIFF
--- a/influxdb-grafana/build/grafana/dashboards/loadtest.json
+++ b/influxdb-grafana/build/grafana/dashboards/loadtest.json
@@ -68,9 +68,9 @@
             {
               "target": "",
               "function": "median",
-              "column": "requests_per_second",
+              "column": "value",
               "series": "trogdor_rps",
-              "query": "select request_key, median(requests_per_second) from \"trogdor_rps\" where $timeFilter group by time($interval), request_key fill(0) order asc",
+              "query": "select request_key, median(value) from \"trogdor_rps\" where $timeFilter group by time($interval), request_key fill(0) order asc",
               "fill": "0",
               "groupby_field": "request_key"
             }
@@ -140,9 +140,9 @@
           "targets": [
             {
               "function": "median",
-              "column": "response_time",
+              "column": "value",
               "series": "trogdor_rts",
-              "query": "select median(response_time) from \"trogdor_rts\" where $timeFilter group by time($interval) order asc"
+              "query": "select median(value) from \"trogdor_rts\" where $timeFilter group by time($interval) order asc"
             }
           ],
           "aliasColors": {},

--- a/influxdb-grafana/grafana-controller.yaml
+++ b/influxdb-grafana/grafana-controller.yaml
@@ -24,7 +24,7 @@ spec:
           name: grafana
           env:
             - name: GRAFANA_DEFAULT_DASHBOARD
-              value: /dashboard/file/trogdor.json
+              value: /dashboard/file/loadtest.json
             - name: INFLUXDB_EXTERNAL_URL
               value: http://$INFLUXDB_EXTERNAL_HOST:8086/db/
             - name: INFLUXDB_HOST

--- a/loadtest/build/load_generator/scripts/locustfile.py
+++ b/loadtest/build/load_generator/scripts/locustfile.py
@@ -2,6 +2,7 @@ import logging
 import gevent
 import pprint
 import os
+import time
 from gevent.queue import Queue
 from locust import HttpLocust, TaskSet, task, events
 from influxdb.influxdb08 import InfluxDBClient
@@ -18,45 +19,64 @@ influx_queue = Queue()
 def influx_worker():
   """The worker pops each item off the queue and sends it to influxdb."""
   while True:
-      data = influx_queue.get()
-      json_body = None
-      if 'requests_per_second' in data:
-        json_body = [{
-          "Points": [[data['request_key'], data['requests_per_second'], data['epoch_time']]],
-          "Name": "trogdor_rps",
-          "Columns": ["request_key", "requests_per_second", "epoch_time"]
-        }]
-      else:
-        json_body = [{
-          "Points": [[data['request_key'], data['response_time'], data['epoch_time']]],
-          "Name": "trogdor_rts",
-          "Columns": ["request_key", "response_time", "epoch_time"]
-        }]
+    data = influx_queue.get()
+    name = data['name']
+    receipt_time = data.pop('received_time')
 
-      influx_client.write_points (json_body)
-      logging.debug('Wrote %s', pprint.pformat(data, 2))
+    write_to_influx(data)
+
+    data['time'] = receipt_time
+    data['name'] = name + ".received"
+    write_to_influx(data)
+
+    data['time'] = int(time.time())
+    data['name'] = name + ".written"
+    write_to_influx(data)
+
+def write_to_influx(data):
+  data = dict(data)
+  name = data.pop('name')
+  columns = sorted(data.keys())
+  points = map(data.get, columns)
+  json_body = [{ "name": name, "columns": columns, "points": [points] }]
+  influx_client.write_points (json_body)
+  # logging.debug('Wrote %s', pprint.pformat(json_body, 2))
 
 def get_requests_per_second(stat, client_id):
-    request = stat['method'] + stat['name'].replace('/', '-')
-    request_key = "locust.{0}.reqs_per_sec.{1}".format(request, client_id)
+  request = stat['method'] + stat['name'].replace('/', '-')
+  request_key = "locust.{0}.reqs_per_sec.{1}".format(request, client_id)
 
-    for epoch_time, count in stat['num_reqs_per_sec'].items():
-      influx_queue.put( {'request_key':request_key, 'requests_per_second':count, 'epoch_time':epoch_time} )
+  for epoch_time, count in stat['num_reqs_per_sec'].items():
+    now = int(time.time())
+    influx_queue.put({
+      'name': 'trogdor_rps',
+      'value': count,
+      'time': epoch_time, 
+      'request_key': request_key,
+      'received_time': now
+    })
 
 def get_response_time(stat, client_id):
-    request = stat['method'] + stat['name'].replace('/', '-')
+  request = stat['method'] + stat['name'].replace('/', '-')
 
-    request_key = "locust.{0}.response_time.{1}".format(request, client_id)
-    epoch_time = int(stat['start_time'])
+  request_key = "locust.{0}.response_time.{1}".format(request, client_id)
+  epoch_time = int(stat['start_time'])
 
-    # flatten a dictionary of {time: count} to [time, time, time, ...]
-    response_times = []
-    for t, count in stat['response_times'].iteritems():
-        for _ in xrange(count):
-            response_times.append(t)
+  # flatten a dictionary of {time: count} to [time, time, time, ...]
+  response_times = []
+  for t, count in stat['response_times'].iteritems():
+    for _ in xrange(count):
+      response_times.append(t)
 
-    for response_time in response_times:
-      influx_queue.put( {'request_key':request_key, 'response_time':response_time, 'epoch_time':epoch_time} )
+  for response_time in response_times:
+    now = int(time.time())
+    influx_queue.put({
+      'name': 'trogdor_rts',
+      'value': response_time,
+      'time': epoch_time,
+      'request_key': request_key,
+      'received_time': now
+    })
 
 def slave_report_log (client_id, data, ** kw):
   for stat in data['stats']:


### PR DESCRIPTION
InfluxDB / Grafana don't really play well with the idea of using
alternate columns for time.  So series-per-time it is.

New series:
- trogdor_rps
- trogdor_rps.received
- trogdor_rps.written
- (ditto for trogdor_rts)

Values are now in 'value' column

Updated grafana dashboard, renamed to 'loadtest'