### PR TITLE
Slim down samsung_ag/trogdor-framework image

### DIFF
--- a/loadtest/build/web_service/Dockerfile
+++ b/loadtest/build/web_service/Dockerfile
@@ -1,2 +1,4 @@
-FROM golang:1.3-onbuild
+FROM scratch
 EXPOSE 9080
+COPY hello /
+ENTRYPOINT ["/hello"]

--- a/loadtest/build/web_service/hello.go
+++ b/loadtest/build/web_service/hello.go
@@ -1,39 +1,39 @@
-package main
+package main // import "hello"
 
 import (
-  "encoding/json"
-  "flag"
-  "net/http"
-  "runtime"
-  "log"
-
+	"encoding/json"
+	"flag"
+	"log"
+	"net/http"
+	"runtime"
 )
 
 type Message struct {
-  Message string `json:"message"`
+	Message string `json:"message"`
 }
 
 const helloWorldString = "Hello, World!"
+
 var debug = flag.Bool("debug", false, "debug logging")
 
 func main() {
-  flag.Parse()
-  runtime.GOMAXPROCS(runtime.NumCPU())
+	flag.Parse()
+	runtime.GOMAXPROCS(runtime.NumCPU())
 
-  http.HandleFunc("/json", jsonHandler)
-  http.ListenAndServe(":9080", Log(http.DefaultServeMux))
+	http.HandleFunc("/json", jsonHandler)
+	http.ListenAndServe(":9080", Log(http.DefaultServeMux))
 }
 
 func Log(handler http.Handler) http.Handler {
-  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    if *debug == true {
-      log.Printf("%s %s %s", r.RemoteAddr, r.Method, r.URL)
-    }
-    handler.ServeHTTP(w, r)
-  })
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if *debug == true {
+			log.Printf("%s %s %s", r.RemoteAddr, r.Method, r.URL)
+		}
+		handler.ServeHTTP(w, r)
+	})
 }
 
 func jsonHandler(w http.ResponseWriter, r *http.Request) {
-  w.Header().Set("Content-Type", "application/json")
-  json.NewEncoder(w).Encode(&Message{helloWorldString})
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(&Message{helloWorldString})
 }


### PR DESCRIPTION
Used centurylink/golang-builder to build the hello binary.  I don't like
checking binaries in, but our CI process currently assumes the
Dockerfile is authoritative.

The hello binary built with:
  docker run --rm -v $(pwd):/src centurylink/golang-builder

This could be scripted away or the golang-builder's docker.sock volume
could be used to automate away the need to check in a binary