### PR TITLE
Average down response times to a single data point

### DIFF
--- a/loadtest/aws/load-master-service.yaml
+++ b/loadtest/aws/load-master-service.yaml
@@ -3,8 +3,11 @@ kind: Service
 apiVersion: v1beta3
 metadata: 
   name: load-generator-master
+  namespace: default
   labels: 
     name: load-generator-master
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "Locust"
 spec: 
   type: NodePort
   ports: 

--- a/loadtest/build/load_generator/scripts/locustfile.py
+++ b/loadtest/build/load_generator/scripts/locustfile.py
@@ -4,43 +4,43 @@ import pprint
 import os
 import time
 from gevent.queue import Queue
+from gevent.threadpool import ThreadPool
 from locust import HttpLocust, TaskSet, task, events
 from influxdb.influxdb08 import InfluxDBClient
 
-host = os.getenv('INFLUXDB_HOST', 'influxdb')
-port = int(os.getenv('INFLUXDB_PORT', '8086'))
-user = os.getenv('INFLUXDB_USER', 'root')
-pw = os.getenv('INFLUXDB_PASSWORD', 'root')
-name = os.getenv('INFLUXDB_NAME', 'k8s')
-
-influx_client = InfluxDBClient (host, port, user, pw, name)
 influx_queue = Queue()
 
 def influx_worker():
   """The worker pops each item off the queue and sends it to influxdb."""
+  host = os.getenv('INFLUXDB_HOST', 'influxdb')
+  port = int(os.getenv('INFLUXDB_PORT', '8086'))
+  user = os.getenv('INFLUXDB_USER', 'root')
+  pw = os.getenv('INFLUXDB_PASSWORD', 'root')
+  name = os.getenv('INFLUXDB_NAME', 'k8s')
+  influx_client = InfluxDBClient (host, port, user, pw, name)
   while True:
     data = influx_queue.get()
     name = data['name']
     receipt_time = data.pop('received_time')
 
-    write_to_influx(data)
+    write_to_influx(influx_client, data)
 
     data['time'] = receipt_time
     data['name'] = name + ".received"
-    write_to_influx(data)
+    write_to_influx(influx_client, data)
 
     data['time'] = int(time.time())
     data['name'] = name + ".written"
-    write_to_influx(data)
+    write_to_influx(influx_client, data)
 
-def write_to_influx(data):
+def write_to_influx(influx_client, data):
   data = dict(data)
   name = data.pop('name')
   columns = sorted(data.keys())
   points = map(data.get, columns)
   json_body = [{ "name": name, "columns": columns, "points": [points] }]
+  logging.info('Writing %s', json_body)
   influx_client.write_points (json_body)
-  # logging.debug('Wrote %s', pprint.pformat(json_body, 2))
 
 def get_requests_per_second(stat, client_id):
   request = stat['method'] + stat['name'].replace('/', '-')
@@ -67,6 +67,9 @@ def get_response_time(stat, client_id):
   for t, count in stat['response_times'].iteritems():
     for _ in xrange(count):
       response_times.append(t)
+
+  # XXX: try averaging down to reduce write load to influx
+  response_times = [ float(stat['total_response_time']) / stat['num_requests'] ]
 
   for response_time in response_times:
     now = int(time.time())
@@ -95,5 +98,5 @@ class JsonSerialization(TaskSet):
 class WebsiteUser(HttpLocust):
   task_set = JsonSerialization
 
-gevent.spawn(influx_worker)
 events.slave_report += slave_report_log
+gevent.spawn(influx_worker)


### PR DESCRIPTION
This should allow us to reduce write volume to influx, at the expense of
granularity.  We were already unpacking from a histogram though, so
probably not that big a deal.

Other tweaks:
- get Locust to show up in cluster-info
- make influx_client local to worker, might be able to ramp up number of
  workers