### PR TITLE
Update kubernetes resources to v1 api

### DIFF
--- a/guestbook/frontend-controller.json
+++ b/guestbook/frontend-controller.json
@@ -1,37 +1,41 @@
 {
-   "kind":"ReplicationController",
-   "apiVersion":"v1beta3",
-   "metadata":{
-      "name":"frontend",
-      "labels":{
-         "name":"frontend"
-      }
-   },
-   "spec":{
-      "replicas":2,
-      "selector":{
-         "name":"frontend"
+  "kind": "ReplicationController",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "frontend",
+    "namespace": "default",
+    "labels": {
+      "name": "frontend"
+    }
+  },
+  "spec": {
+    "replicas": 2,
+    "selector": {
+      "name": "frontend"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "name": "frontend"
+        }
       },
-      "template":{
-         "metadata":{
-            "labels":{
-               "name":"frontend"
-            }
-         },
-         "spec":{
-            "containers":[
-               {
-                  "name":"php-redis",
-                  "image":"kubernetes/example-guestbook-php-redis:v2",
-                  "ports":[
-                     {
-                        "containerPort":80,
-                        "protocol":"TCP"
-                     }
-                  ]
-               }
-            ]
-         }
+      "spec": {
+        "containers": [
+          {
+            "name": "php-redis",
+            "image": "kubernetes/example-guestbook-php-redis:v2",
+            "ports": [
+              {
+                "containerPort": 80,
+                "protocol": "TCP"
+              }
+            ],
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "dnsPolicy": "ClusterFirst"
       }
-   }
+    }
+  }
 }

--- a/guestbook/frontend-service.json
+++ b/guestbook/frontend-service.json
@@ -1,23 +1,29 @@
 {
-   "kind":"Service",
-   "apiVersion":"v1beta3",
-   "metadata":{
-      "name":"frontend",
-      "labels":{
-         "name":"frontend"
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "frontend",
+    "namespace": "default",
+    "labels": {
+      "name": "frontend"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 80,
+        "targetPort": 80,
+        "nodePort": 0
       }
-   },
-   "spec":{
-      "ports": [
-        {
-          "port":80,
-          "targetPort":80,
-          "protocol":"TCP"
-        }
-      ],
-      "publicIPs": [ "$SERVICE_IP" ],
-      "selector":{
-         "name":"frontend"
-      }
-   }
+    ],
+    "selector": {
+      "name": "frontend"
+    },
+    "type": "ClusterIP",
+    "deprecatedPublicIPs": [
+      "$SERVICE_IP"
+    ],
+    "sessionAffinity": "None"
+  }
 }

--- a/guestbook/redis-master-service.json
+++ b/guestbook/redis-master-service.json
@@ -1,22 +1,26 @@
 {
-   "kind":"Service",
-   "apiVersion":"v1beta3",
-   "metadata":{
-      "name":"redis-master",
-      "labels":{
-         "name":"redis-master"
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "redis-master",
+    "namespace": "default",
+    "labels": {
+      "name": "redis-master"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 6379,
+        "targetPort": 6379,
+        "nodePort": 0
       }
-   },
-   "spec":{
-      "ports": [
-        {
-          "port":6379,
-          "targetPort":6379,
-          "protocol":"TCP"
-        }
-      ],
-      "selector":{
-         "name":"redis-master"
-      }
-   }
+    ],
+    "selector": {
+      "name": "redis-master"
+    },
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  }
 }

--- a/guestbook/redis-master.json
+++ b/guestbook/redis-master.json
@@ -1,37 +1,41 @@
 {
-   "kind":"ReplicationController",
-   "apiVersion":"v1beta3",
-   "metadata":{
-      "name":"redis-master",
-      "labels":{
-         "name":"redis-master"
-      }
-   },
-   "spec":{
-      "replicas":1,
-      "selector":{
-         "name":"redis-master"
+  "kind": "ReplicationController",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "redis-master",
+    "namespace": "default",
+    "labels": {
+      "name": "redis-master"
+    }
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "name": "redis-master"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "name": "redis-master"
+        }
       },
-      "template":{
-         "metadata":{
-            "labels":{
-               "name":"redis-master"
-            }
-         },
-         "spec":{
-            "containers":[
-               {
-                  "name":"master",
-                  "image":"dockerfiles/redis",
-                  "ports":[
-                     {
-                        "containerPort":6379,
-                        "protocol":"TCP"
-                     }
-                  ]
-               }
-            ]
-         }
+      "spec": {
+        "containers": [
+          {
+            "name": "master",
+            "image": "dockerfiles/redis",
+            "ports": [
+              {
+                "containerPort": 6379,
+                "protocol": "TCP"
+              }
+            ],
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "dnsPolicy": "ClusterFirst"
       }
-   }
+    }
+  }
 }

--- a/guestbook/redis-slave-controller.json
+++ b/guestbook/redis-slave-controller.json
@@ -1,37 +1,41 @@
 {
-   "kind":"ReplicationController",
-   "apiVersion":"v1beta3",
-   "metadata":{
-      "name":"redis-slave",
-      "labels":{
-         "name":"redis-slave"
-      }
-   },
-   "spec":{
-      "replicas":2,
-      "selector":{
-         "name":"redis-slave"
+  "kind": "ReplicationController",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "redis-slave",
+    "namespace": "default",
+    "labels": {
+      "name": "redis-slave"
+    }
+  },
+  "spec": {
+    "replicas": 2,
+    "selector": {
+      "name": "redis-slave"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "name": "redis-slave"
+        }
       },
-      "template":{
-         "metadata":{
-            "labels":{
-               "name":"redis-slave"
-            }
-         },
-         "spec":{
-            "containers":[
-               {
-                  "name":"slave",
-                  "image":"kubernetes/redis-slave:v2",
-                  "ports":[
-                     {
-                        "containerPort":6379,
-                        "protocol":"TCP"
-                     }
-                  ]
-               }
-            ]
-         }
+      "spec": {
+        "containers": [
+          {
+            "name": "slave",
+            "image": "kubernetes/redis-slave:v2",
+            "ports": [
+              {
+                "containerPort": 6379,
+                "protocol": "TCP"
+              }
+            ],
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "dnsPolicy": "ClusterFirst"
       }
-   }
+    }
+  }
 }

--- a/guestbook/redis-slave-service.json
+++ b/guestbook/redis-slave-service.json
@@ -1,22 +1,25 @@
 {
-   "kind":"Service",
-   "apiVersion":"v1beta3",
-   "metadata":{
-      "name":"redis-slave",
-      "labels":{
-         "name":"redis-slave"
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "redis-slave",
+    "namespace": "default",
+    "labels": {
+      "name": "redis-slave"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "protocol": "TCP",
+        "port": 6379,
+        "targetPort": 6379,
+        "nodePort": 0
       }
-   },
-   "spec":{
-      "ports": [
-        {
-          "port":6379,
-          "targetPort":6379,
-          "protocol":"TCP"
-        }
-      ],
-      "selector":{
-         "name":"redis-slave"
-      }
-   }
-}
+    ],
+    "selector": {
+      "name": "redis-slave"
+    },
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  }

--- a/heapster/heapster-controller.yaml
+++ b/heapster/heapster-controller.yaml
@@ -22,11 +22,11 @@ spec:
       containers:
       - command:
         - /heapster
-        - --source=kubernetes:https://kubernetes?apiVersion=v1&insecure=true&inClusterConfigFile=false&auth=
+        - --source=kubernetes:https://kubernetes?apiVersion=v1&insecure=true&inClusterConfig=false
         - --sink=influxdb:http://influxdb:8086?avoidColumns=true
         - --poll_duration=10s
         - --stats_resolution=5s
-        image: gcr.io/google_containers/heapster:v0.14.2
+        image: gcr.io/google_containers/heapster:v0.15.0
         imagePullPolicy: IfNotPresent
         name: heapster
         volumeMounts:

--- a/heapster/heapster-controller.yaml
+++ b/heapster/heapster-controller.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v1
-  namespace: default
   labels:
     k8s-app: heapster
-    version: v1
     kubernetes.io/cluster-service: "true"
+    version: v1
+  name: heapster-v1
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -16,30 +16,26 @@ spec:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1
         kubernetes.io/cluster-service: "true"
+        version: v1
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v0.14.2
-          name: heapster
-          command:
-            - /heapster
-            - --source=kubernetes:https://kubernetes?apiVersion=v1beta3&insecure=true&inClusterConfigFile=false&auth=
-            - --sink=influxdb:http://influxdb:8086?avoidColumns=true
-            - --poll_duration=2m
-            - --stats_resolution=1m
-          volumeMounts:
-            - name: ssl-certs
-              mountPath: /etc/ssl/certs
-              readOnly: true
-            # - name: monitoring-token
-            #  mountPath: /etc/kubernetes/kubeconfig
-            #  readOnly: true
-
+      - command:
+        - /heapster
+        - --source=kubernetes:https://kubernetes?apiVersion=v1&insecure=true&inClusterConfigFile=false&auth=
+        - --sink=influxdb:http://influxdb:8086?avoidColumns=true
+        - --poll_duration=10s
+        - --stats_resolution=5s
+        image: gcr.io/google_containers/heapster:v0.14.2
+        imagePullPolicy: IfNotPresent
+        name: heapster
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: ssl-certs
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
       volumes:
-        - name: ssl-certs
-          hostPath:
-            path: /etc/ssl/certs
-        # - name: monitoring-token
-        #  secret:
-        #    secretName: token-system-monitoring
+      - hostPath:
+          path: /etc/ssl/certs
+        name: ssl-certs

--- a/heapster/heapster-service.yaml
+++ b/heapster/heapster-service.yaml
@@ -1,17 +1,21 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: Service
 metadata:
-  name: heapster
-  namespace: default
   labels:
     k8s-app: Heapster
     kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "Heapster"
+    kubernetes.io/name: Heapster
+  name: heapster
+  namespace: default
 spec:
+  deprecatedPublicIPs:
+  - $HEAPSTER_PUBLIC_IP
   ports:
-    - port: 8082
-      targetPort: 8082
+  - nodePort: 0
+    port: 8082
+    protocol: TCP
+    targetPort: 8082
   selector:
     k8s-app: Heapster
-  publicIPs:
-    - "$HEAPSTER_PUBLIC_IP"
+  sessionAffinity: None
+  type: ClusterIP

--- a/influxdb-grafana/grafana-controller.yaml
+++ b/influxdb-grafana/grafana-controller.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: grafana-v1
-  namespace: default
   labels:
     k8s-app: Grafana
-    version: v1
     kubernetes.io/cluster-service: "true"
+    version: v1
+  name: grafana-v1
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -16,18 +16,21 @@ spec:
     metadata:
       labels:
         k8s-app: Grafana
-        version: v1
         kubernetes.io/cluster-service: "true"
+        version: v1
     spec:
       containers:
-        - image: quay.io/samsung_ag/grafana:latest
-          name: grafana
-          env:
-            - name: GRAFANA_DEFAULT_DASHBOARD
-              value: /dashboard/file/loadtest.json
-            - name: INFLUXDB_EXTERNAL_URL
-              value: http://$INFLUXDB_EXTERNAL_HOST:8086/db/
-            - name: INFLUXDB_HOST
-              value: influxdb
-            - name: INFLUXDB_PORT
-              value: "8086"
+      - env:
+        - name: GRAFANA_DEFAULT_DASHBOARD
+          value: /dashboard/file/loadtest.json
+        - name: INFLUXDB_EXTERNAL_URL
+          value: http://$INFLUXDB_EXTERNAL_HOST:8086/db/
+        - name: INFLUXDB_HOST
+          value: influxdb
+        - name: INFLUXDB_PORT
+          value: "8086"
+        image: quay.io/samsung_ag/grafana:latest
+        imagePullPolicy: Always
+        name: grafana
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always

--- a/influxdb-grafana/grafana-service.yaml
+++ b/influxdb-grafana/grafana-service.yaml
@@ -1,16 +1,20 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: Service
 metadata:
-  name: grafana
-  namespace: default
   labels:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: Grafana
+  name: grafana
+  namespace: default
 spec:
+  deprecatedPublicIPs:
+  - $GRAFANA_PUBLIC_IP
   ports:
-    - port: 8002
-      targetPort: 8080
+  - nodePort: 0
+    port: 8002
+    protocol: TCP
+    targetPort: 8080
   selector:
     k8s-app: Grafana
-  publicIPs:
-    - $GRAFANA_PUBLIC_IP
+  sessionAffinity: None
+  type: ClusterIP

--- a/influxdb-grafana/influxdb-controller.yaml
+++ b/influxdb-grafana/influxdb-controller.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: influxdb-v1
-  namespace: default
   labels:
     k8s-app: InfluxDB
-    version: v1
     kubernetes.io/cluster-service: "true"
+    version: v1
+  name: influxdb-v1
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -16,21 +16,26 @@ spec:
     metadata:
       labels:
         k8s-app: InfluxDB
-        version: v1
         kubernetes.io/cluster-service: "true"
+        version: v1
     spec:
       containers:
-        - image: quay.io/samsung_ag/influxdb:latest
-          name: influxdb
-          ports:
-            - containerPort: 8083
-              hostPort: 8083
-            - containerPort: 8086
-              hostPort: 8086
-          env:
-            - name: INFLUXDB_INIT_PWD
-              value: root
-            - name: PRE_CREATE_DB
-              value: k8s;grafana 
+      - env:
+        - name: INFLUXDB_INIT_PWD
+          value: root
+        - name: PRE_CREATE_DB
+          value: k8s;grafana
+        image: quay.io/samsung_ag/influxdb:latest
+        imagePullPolicy: Always
+        name: influxdb
+        ports:
+        - containerPort: 8083
+          hostPort: 8083
+          protocol: TCP
+        - containerPort: 8086
+          hostPort: 8086
+          protocol: TCP
+      dnsPolicy: ClusterFirst
       nodeSelector:
         kraken-node: node-01
+      restartPolicy: Always

--- a/influxdb-grafana/influxdb-service.yaml
+++ b/influxdb-grafana/influxdb-service.yaml
@@ -1,21 +1,27 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: Service
 metadata:
-  name: influxdb
-  namespace: default
   labels:
     k8s-app: InfluxDB
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: InfluxDB
+  name: influxdb
+  namespace: default
 spec:
+  deprecatedPublicIPs:
+  - $INFLUXDB_PUBLIC_IP
   ports:
-    - name: http
-      port: 8083
-      targetPort: 8083
-    - name: api
-      port: 8086
-      targetPort: 8086
+  - name: http
+    nodePort: 0
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+  - name: api
+    nodePort: 0
+    port: 8086
+    protocol: TCP
+    targetPort: 8086
   selector:
     k8s-app: InfluxDB
-  publicIPs:
-    - $INFLUXDB_PUBLIC_IP
+  sessionAffinity: None
+  type: ClusterIP

--- a/loadtest/aws/load-master-service.yaml
+++ b/loadtest/aws/load-master-service.yaml
@@ -1,32 +1,30 @@
----
+apiVersion: v1
 kind: Service
-apiVersion: v1beta3
-metadata: 
+metadata:
+  labels:
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: Locust
+    name: load-generator-master
   name: load-generator-master
   namespace: default
-  labels: 
+spec:
+  ports:
+  - name: locust-http
+    nodePort: 30061
+    port: 8089
+    protocol: TCP
+    targetPort: 8089
+  - name: locust-slavecomm
+    nodePort: 30082
+    port: 5557
+    protocol: TCP
+    targetPort: 5557
+  - name: locust-slavecomm2
+    nodePort: 30967
+    port: 5558
+    protocol: TCP
+    targetPort: 5558
+  selector:
     name: load-generator-master
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "Locust"
-spec: 
+  sessionAffinity: None
   type: NodePort
-  ports: 
-    - 
-      port: 8089
-      targetPort: 8089
-      name: locust-http
-      protocol: TCP
-      NodePort: 30061
-    - 
-      port: 5557
-      targetPort: 5557
-      name: locust-slavecomm
-      protocol: TCP
-    - 
-      port: 5558
-      targetPort: 5558
-      name: locust-slavecomm2
-      protocol: TCP
-  serviceType: NodePort
-  selector: 
-    name: load-generator-master

--- a/loadtest/common/framework-controller.yaml
+++ b/loadtest/common/framework-controller.yaml
@@ -1,24 +1,25 @@
----
+apiVersion: v1
 kind: ReplicationController
-apiVersion: v1beta3
-metadata: 
+metadata:
+  labels:
+    name: framework
   name: framework
-  labels: 
-    name: framework
-spec: 
+  namespace: default
+spec:
   replicas: 10
-  selector: 
+  selector:
     name: framework
-  template: 
-    metadata: 
-      labels: 
+  template:
+    metadata:
+      labels:
         name: framework
-    spec: 
-      containers: 
-        - 
-          name: framework
-          image: quay.io/samsung_ag/trogdor-framework:latest
-          ports: 
-            - 
-              containerPort: 9080
-              protocol: TCP
+    spec:
+      containers:
+      - image: quay.io/samsung_ag/trogdor-framework:latest
+        imagePullPolicy: Always
+        name: framework
+        ports:
+        - containerPort: 9080
+          protocol: TCP
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always

--- a/loadtest/common/framework-service.yaml
+++ b/loadtest/common/framework-service.yaml
@@ -1,15 +1,17 @@
----
+apiVersion: v1
 kind: Service
-apiVersion: v1beta3
-metadata: 
+metadata:
+  labels:
+    name: framework
   name: framework
-  labels: 
+  namespace: default
+spec:
+  ports:
+  - nodePort: 0
+    port: 9080
+    protocol: TCP
+    targetPort: 9080
+  selector:
     name: framework
-spec: 
-  ports: 
-    - 
-      port: 9080
-      targetPort: 9080
-      protocol: TCP
-  selector: 
-    name: framework
+  sessionAffinity: None
+  type: ClusterIP

--- a/loadtest/common/load-master-controller.yaml
+++ b/loadtest/common/load-master-controller.yaml
@@ -1,52 +1,46 @@
----
+apiVersion: v1
 kind: ReplicationController
-apiVersion: v1beta3
-metadata: 
+metadata:
+  labels:
+    name: load-generator-master
   name: load-generator-master
-  labels: 
-    name: load-generator-master
-spec: 
+  namespace: default
+spec:
   replicas: 1
-  selector: 
+  selector:
     name: load-generator-master
-  template: 
-    metadata: 
-      labels: 
+  template:
+    metadata:
+      labels:
         name: load-generator-master
-    spec: 
-      containers: 
-        - 
-          name: load-generator-master
-          image: quay.io/samsung_ag/trogdor-load-generator:latest
-          command: 
-            - locust
-            - -f
-            - /scripts/locustfile.py
-            - --master
-            - --host=http://framework:9080
-          ports: 
-            - 
-              containerPort: 8089
-              protocol: TCP
-            - 
-              containerPort: 5557
-              protocol: TCP
-            - 
-              containerPort: 5558
-              protocol: TCP
-          env: 
-            - 
-              name: INFLUXDB_HOST
-              value: influxdb
-            - 
-              name: INFLUXDB_PORT
-              value: "8086"
-            - 
-              name: INFLUXDB_USER
-              value: root
-            - 
-              name: INFLUXDB_PASSWORD
-              value: root
-            - 
-              name: INFLUXDB_NAME
-              value: k8s
+    spec:
+      containers:
+      - command:
+        - locust
+        - -f
+        - /scripts/locustfile.py
+        - --master
+        - --host=http://framework:9080
+        env:
+        - name: INFLUXDB_HOST
+          value: influxdb
+        - name: INFLUXDB_PORT
+          value: "8086"
+        - name: INFLUXDB_USER
+          value: root
+        - name: INFLUXDB_PASSWORD
+          value: root
+        - name: INFLUXDB_NAME
+          value: k8s
+        image: quay.io/samsung_ag/trogdor-load-generator:latest
+        imagePullPolicy: Always
+        name: load-generator-master
+        ports:
+        - containerPort: 8089
+          protocol: TCP
+        - containerPort: 5557
+          protocol: TCP
+        - containerPort: 5558
+          protocol: TCP
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always

--- a/loadtest/common/load-slave-controller.yaml
+++ b/loadtest/common/load-slave-controller.yaml
@@ -1,43 +1,40 @@
----
+apiVersion: v1
 kind: ReplicationController
-apiVersion: v1beta3
-metadata: 
+metadata:
+  labels:
+    name: load-generator-slave
   name: load-generator-slave
-  labels: 
-    name: load-generator-slave
-spec: 
+  namespace: default
+spec:
   replicas: 5
-  selector: 
+  selector:
     name: load-generator-slave
-  template: 
-    metadata: 
-      labels: 
+  template:
+    metadata:
+      labels:
         name: load-generator-slave
-    spec: 
-      containers: 
-        - 
-          name: load-generator-slave
-          image: quay.io/samsung_ag/trogdor-load-generator:latest
-          command: 
-            - locust
-            - -f
-            - /scripts/locustfile.py
-            - --slave
-            - --master-host=load-generator-master
-            - --host=http://framework:9080
-          env: 
-            - 
-              name: INFLUXDB_HOST
-              value: influxdb
-            - 
-              name: INFLUXDB_PORT
-              value: "8086"
-            - 
-              name: INFLUXDB_USER
-              value: root
-            - 
-              name: INFLUXDB_PASSWORD
-              value: root
-            - 
-              name: INFLUXDB_NAME
-              value: k8s
+    spec:
+      containers:
+      - command:
+        - locust
+        - -f
+        - /scripts/locustfile.py
+        - --slave
+        - --master-host=load-generator-master
+        - --host=http://framework:9080
+        env:
+        - name: INFLUXDB_HOST
+          value: influxdb
+        - name: INFLUXDB_PORT
+          value: "8086"
+        - name: INFLUXDB_USER
+          value: root
+        - name: INFLUXDB_PASSWORD
+          value: root
+        - name: INFLUXDB_NAME
+          value: k8s
+        image: quay.io/samsung_ag/trogdor-load-generator:latest
+        imagePullPolicy: Always
+        name: load-generator-slave
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always

--- a/loadtest/local/load-master-service.yaml
+++ b/loadtest/local/load-master-service.yaml
@@ -1,28 +1,30 @@
----
+apiVersion: v1
 kind: Service
-apiVersion: v1beta3
 metadata:
-  name: load-generator-master
   labels:
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: Locust
     name: load-generator-master
+  name: load-generator-master
+  namespace: default
 spec:
+  deprecatedPublicIPs:
+  - 172.16.1.103
   ports:
-    -
-      port: 8089
-      targetPort: 8089
-      name: locust-http
-      protocol: TCP
-    -
-      port: 5557
-      targetPort: 5557
-      name: locust-slavecomm
-      protocol: TCP
-    -
-      port: 5558
-      targetPort: 5558
-      name: locust-slavecomm2
-      protocol: TCP
-  publicIPs:
-    - 172.16.1.103
+  - name: locust-http
+    nodePort: 0
+    port: 8089
+    protocol: TCP
+    targetPort: 8089
+  - name: locust-slavecomm
+    nodePort: 0
+    port: 5557
+    protocol: TCP
+    targetPort: 5557
+  - name: locust-slavecomm2
+    nodePort: 0
+    port: 5558
+    protocol: TCP
+    targetPort: 5558
   selector:
     name: load-generator-master

--- a/loadtest/nuc/framework-controller.yaml
+++ b/loadtest/nuc/framework-controller.yaml
@@ -1,26 +1,27 @@
----
+apiVersion: v1
 kind: ReplicationController
-apiVersion: v1beta3
-metadata: 
+metadata:
+  labels:
+    name: framework
   name: framework
-  labels: 
-    name: framework
-spec: 
+  namespace: default
+spec:
   replicas: 10
-  selector: 
+  selector:
     name: framework
-  template: 
-    metadata: 
-      labels: 
+  template:
+    metadata:
+      labels:
         name: framework
-    spec: 
-      containers: 
-        - 
-          name: framework
-          image: 172.16.16.15:5000/trogdor-framework:1
-          ports: 
-            - 
-              containerPort: 9080
-              protocol: TCP
-      nodeSelector:
-        region: zone3
+    spec:
+      containers:
+      - image: 172.16.16.15:5000/trogdor-framework:1
+        imagePullPolicy: IfNotPresent
+        name: framework
+        ports:
+        - containerPort: 9080
+          protocol: TCP
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+    nodeSelector:
+      region: zone3

--- a/loadtest/nuc/framework-service.yaml
+++ b/loadtest/nuc/framework-service.yaml
@@ -1,15 +1,17 @@
----
+apiVersion: v1
 kind: Service
-apiVersion: v1beta3
-metadata: 
+metadata:
+  labels:
+    name: framework
   name: framework
-  labels: 
+  namespace: default
+spec:
+  ports:
+  - nodePort: 0
+    port: 9080
+    protocol: TCP
+    targetPort: 9080
+  selector:
     name: framework
-spec: 
-  ports: 
-    - 
-      port: 9080
-      targetPort: 9080
-      protocol: TCP
-  selector: 
-    name: framework
+  sessionAffinity: None
+  type: ClusterIP

--- a/loadtest/nuc/load-master-controller.yaml
+++ b/loadtest/nuc/load-master-controller.yaml
@@ -1,54 +1,48 @@
----
+apiVersion: v1
 kind: ReplicationController
-apiVersion: v1beta3
-metadata: 
+metadata:
+  labels:
+    name: load-generator-master
   name: load-generator-master
-  labels: 
-    name: load-generator-master
-spec: 
+  namespace: default
+spec:
   replicas: 1
-  selector: 
+  selector:
     name: load-generator-master
-  template: 
-    metadata: 
-      labels: 
+  template:
+    metadata:
+      labels:
         name: load-generator-master
-    spec: 
-      containers: 
-        - 
-          name: load-generator-master
-          image: 172.16.16.15:5000/trogdor-load-generator:nuc
-          command: 
-            - locust
-            - -f
-            - /scripts/locustfile.py
-            - --master
-            - --host=http://framework:9080
-          ports: 
-            - 
-              containerPort: 8089
-              protocol: TCP
-            - 
-              containerPort: 5557
-              protocol: TCP
-            - 
-              containerPort: 5558
-              protocol: TCP
-          env: 
-            - 
-              name: INFLUXDB_HOST
-              value: influxdb
-            - 
-              name: INFLUXDB_PORT
-              value: "8086"
-            - 
-              name: INFLUXDB_USER
-              value: root
-            - 
-              name: INFLUXDB_PASSWORD
-              value: root
-            - 
-              name: INFLUXDB_NAME
-              value: k8s
+    spec:
+      containers:
+      - command:
+        - locust
+        - -f
+        - /scripts/locustfile.py
+        - --master
+        - --host=http://framework:9080
+        env:
+        - name: INFLUXDB_HOST
+          value: influxdb
+        - name: INFLUXDB_PORT
+          value: "8086"
+        - name: INFLUXDB_USER
+          value: root
+        - name: INFLUXDB_PASSWORD
+          value: root
+        - name: INFLUXDB_NAME
+          value: k8s
+        image: 172.16.16.15:5000/trogdor-load-generator:nuc
+        imagePullPolicy: IfNotPresent
+        name: load-generator-master
+        ports:
+        - containerPort: 8089
+          protocol: TCP
+        - containerPort: 5557
+          protocol: TCP
+        - containerPort: 5558
+          protocol: TCP
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
       nodeSelector:
         region: zone1

--- a/loadtest/nuc/load-master-service.yaml
+++ b/loadtest/nuc/load-master-service.yaml
@@ -1,28 +1,30 @@
----
+apiVersion: v1
 kind: Service
-apiVersion: v1beta3
 metadata:
-  name: load-generator-master
   labels:
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: Locust
     name: load-generator-master
+  name: load-generator-master
+  namespace: default
 spec:
+  deprecatedPublicIPs:
+  - 172.16.16.16
   ports:
-    -
-      port: 8089
-      targetPort: 8089
-      name: locust-http
-      protocol: TCP
-    -
-      port: 5557
-      targetPort: 5557
-      name: locust-slavecomm
-      protocol: TCP
-    -
-      port: 5558
-      targetPort: 5558
-      name: locust-slavecomm2
-      protocol: TCP
-  publicIPs:
-    - 172.16.16.16
+  - name: locust-http
+    nodePort: 0
+    port: 8089
+    protocol: TCP
+    targetPort: 8089
+  - name: locust-slavecomm
+    nodePort: 0
+    port: 5557
+    protocol: TCP
+    targetPort: 5557
+  - name: locust-slavecomm2
+    nodePort: 0
+    port: 5558
+    protocol: TCP
+    targetPort: 5558
   selector:
     name: load-generator-master

--- a/loadtest/nuc/load-slave-controller.yaml
+++ b/loadtest/nuc/load-slave-controller.yaml
@@ -1,45 +1,42 @@
----
+apiVersion: v1
 kind: ReplicationController
-apiVersion: v1beta3
-metadata: 
+metadata:
+  labels:
+    name: load-generator-slave
   name: load-generator-slave
-  labels: 
-    name: load-generator-slave
-spec: 
+  namespace: default
+spec:
   replicas: 5
-  selector: 
+  selector:
     name: load-generator-slave
-  template: 
-    metadata: 
-      labels: 
+  template:
+    metadata:
+      labels:
         name: load-generator-slave
-    spec: 
-      containers: 
-        - 
-          name: load-generator-slave
-          image: 172.16.16.15:5000/trogdor-load-generator:nuc
-          command: 
-            - locust
-            - -f
-            - /scripts/locustfile.py
-            - --slave
-            - --master-host=load-generator-master
-            - --host=http://framework:9080
-          env: 
-            - 
-              name: INFLUXDB_HOST
-              value: influxdb
-            - 
-              name: INFLUXDB_PORT
-              value: "8086"
-            - 
-              name: INFLUXDB_USER
-              value: root
-            - 
-              name: INFLUXDB_PASSWORD
-              value: root
-            - 
-              name: INFLUXDB_NAME
-              value: k8s
+    spec:
+      containers:
+      - command:
+        - locust
+        - -f
+        - /scripts/locustfile.py
+        - --slave
+        - --master-host=load-generator-master
+        - --host=http://framework:9080
+        env:
+        - name: INFLUXDB_HOST
+          value: influxdb
+        - name: INFLUXDB_PORT
+          value: "8086"
+        - name: INFLUXDB_USER
+          value: root
+        - name: INFLUXDB_PASSWORD
+          value: root
+        - name: INFLUXDB_NAME
+          value: k8s
+        image: 172.16.16.15:5000/trogdor-load-generator:nuc
+        imagePullPolicy: IfNotPresent
+        name: load-generator-slave
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
       nodeSelector:
         region: zone2

--- a/skydns/skydns-rc.yaml
+++ b/skydns/skydns-rc.yaml
@@ -1,12 +1,12 @@
 # based on https://github.com/GoogleCloudPlatform/kubernetes/blob/master/cluster/addons/dns/skydns-rc.yaml.in
-apiVersion: v1beta3
+apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v3
-  namespace: default
   labels:
     k8s-app: kube-dns-v3
     kubernetes.io/cluster-service: "true"
+  name: kube-dns-v3
+  namespace: default
 spec:
   replicas: 3
   selector:

--- a/skydns/skydns-svc.yaml
+++ b/skydns/skydns-svc.yaml
@@ -1,17 +1,14 @@
 # based on https://github.com/GoogleCloudPlatform/kubernetes/blob/master/cluster/addons/dns/skydns-svc.yaml.in
-apiVersion: v1beta3
+apiVersion: v1
 kind: Service
 metadata:
-  name: kube-dns
-  namespace: default
   labels:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "KubeDNS"
+  name: kube-dns
+  namespace: default
 spec:
-  selector:
-    k8s-app: kube-dns
-  portalIP: 10.100.0.10
   ports:
   - name: dns
     port: 53
@@ -19,3 +16,6 @@ spec:
   - name: dns-tcp
     port: 53
     protocol: TCP
+  selector:
+    k8s-app: kube-dns
+  clusterIP: 10.100.0.10


### PR DESCRIPTION
Tested against
- kubernetes 0.19.3, coreos 695.2.0
- kubernetes 0.20.2, coreos 723.1.0

Couldn't verify the loadtest/nuc resources, didn't verify the guestbook resources