### PR TITLE
Allow more services to be launched on insta-cluster

### DIFF
--- a/prometheus/prometheus-controller.yaml
+++ b/prometheus/prometheus-controller.yaml
@@ -38,7 +38,7 @@ spec:
           value: localhost:8001
         - name: PROMETHEUS_TARGET_ADDRESS
           value: localhost:9090
-        image: quay.io/spiffxp/prometheus:latest
+        image: quay.io/samsung_ag/prometheus:latest
         imagePullPolicy: Always
         name: prometheus
         ports:

--- a/tectonic-ui/tectonic-ui-controller.yaml
+++ b/tectonic-ui/tectonic-ui-controller.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: tectonic-ui
-          image: quay.io/coreos/tectonic-console
+          image: quay.io/samsung_ag/tectonic-ui
           ports:
             - containerPort: 9000
               hostPort: 9000


### PR DESCRIPTION
Use our org's private copy of tectonic-ui, and use our org's built version of prometheus