### PR TITLE
KRAK-105 Add Prom Push Gateway

### DIFF
--- a/prometheus/prometheus-controller.yaml
+++ b/prometheus/prometheus-controller.yaml
@@ -31,7 +31,7 @@ spec:
           name: data
       - args:
         - -t
-        - PROMETHEUS,KUBE_APISERVER,KUBE_CONTROLLER,KUBE_SCHEDULER,APISERVER_ETCD,KUBE_ETCD,APISERVER_CADVISOR,ETCD_CADVISOR
+        - PROMETHEUS,KUBE_APISERVER,KUBE_CONTROLLER,KUBE_SCHEDULER,APISERVER_ETCD,KUBE_ETCD,APISERVER_CADVISOR,ETCD_CADVISOR,PUSHGATEWAY
         - -d
         - /var/prometheus
         - -K
@@ -52,6 +52,8 @@ spec:
           value: $KUBE_APISERVER_IP:8094
         - name: ETCD_CADVISOR_TARGET_ADDRESS
           value: $KUBE_ETCD_IP:8094
+        - name: PUSHGATEWAY_TARGET_ADDRESS
+          value: localhost:9091
         image: quay.io/samsung_ag/prometheus:latest
         imagePullPolicy: Always
         name: prometheus
@@ -62,6 +64,12 @@ spec:
         volumeMounts:
         - mountPath: /var/prometheus/
           name: data
+      - image: "jayunit100/prompush:0.2.0"
+        name:  pushgateway
+        ports:
+        - containerPort: 9091
+          hostPort: 9091
+          protocol: TCP
       - args:
         - proxy
         - --port=8001

--- a/prometheus/prometheus-service.yaml
+++ b/prometheus/prometheus-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,6 +18,10 @@ spec:
     port: 3000
     protocol: TCP
     targetPort: 3000
+  - name: pushgateway
+    port: 9091
+    protocol: TCP
+    targetPort: 9091
   selector:
     name: prometheus
   sessionAffinity: None


### PR DESCRIPTION
Used by e2e tests.

In my cluster, this change seems to cause:

    ------------------
    Using /var/prometheus as the root for prometheus configs and data.
    /usr/lib/ruby/2.2.0/json/common.rb:155:in `initialize': A JSON text must at least contain two octets!       (JSON::ParserError)
	    from /usr/lib/ruby/2.2.0/json/common.rb:155:in `new'
	    from /usr/lib/ruby/2.2.0/json/common.rb:155:in `parse'
	    from /prometheus/run.rb:59:in `build_config'
	    from /prometheus/run.rb:85:in `<main>'
    -------------------
