### PR TITLE
need to monitor kube-dns not kubernetes in this pod

### DIFF
--- a/prometheus/prometheus-service.yaml
+++ b/prometheus/prometheus-service.yaml
@@ -22,6 +22,7 @@ spec:
     port: 9091
     protocol: TCP
     targetPort: 9091
+    nodePort: 30362
   selector:
     name: prometheus
   sessionAffinity: None

--- a/skydns/skydns-rc.yaml
+++ b/skydns/skydns-rc.yaml
@@ -80,6 +80,13 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 30
             timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
         - name: healthz
           image: gcr.io/google_containers/exechealthz:1.0
           resources:
@@ -87,7 +94,7 @@ spec:
               cpu: 10m
               memory: 20Mi
           args:
-            - -cmd=nslookup kubernetes.kube-system.svc.$CLUSTER_DOMAIN localhost >/dev/null
+            - -cmd=nslookup kube-dns.kube-system.svc.$CLUSTER_DOMAIN localhost >/dev/null
             - -port=8080
           ports:
             - containerPort: 8080


### PR DESCRIPTION
KRAK-136

Namespace teething issue.  However, in this case, it found a previously hidden issue.
The healthz check in the skydns pod should be monitoring the skydns service itself, under the name kube-dns.<>.   However, it was monitoring kubernetes.<> in general. (perhaps a copy/paste error from way back?).   The healthProbe was causing skydns to restart, because there is no kubernetes.<> was the wrong name to monitor, so it would always fail the check.

Also, was missing the readinessProbe (in most Google examples).
