### PR TITLE
Pin to specific version of prometheus

### DIFF
--- a/prometheus/build/prometheus/Dockerfile
+++ b/prometheus/build/prometheus/Dockerfile
@@ -1,4 +1,4 @@
-FROM       prom/prometheus
+FROM       prom/prometheus:0.16.1
 MAINTAINER Aaron Crickenberger <spiffxp@gmail.com>
 
 RUN apk add --update ruby ruby-json


### PR DESCRIPTION
I believe this image was last built when `prom/prometheus:0.15.1` was also
tagged as `:latest`.  Let's be explicit and rebuild to get the new
release.