### PR TITLE
kubedash change back to loadbalancer

### DIFF
--- a/kubedash/kube-dash.yaml
+++ b/kubedash/kube-dash.yaml
@@ -51,13 +51,10 @@ metadata:
   name: "kubedash"
   namespace: "kube-system"
 spec:
-  sessionAffinity: None
-  type: NodePort
-  ports:
-    -
-      port: 80
-      protocol: TCP
-      targetPort: 8289
-      nodePort: 30390
-  selector:
-    name: "kubedash"
+    type: "LoadBalancer"
+    ports:
+      -
+        port: 80
+        targetPort: 8289
+    selector:
+      name: "kubedash"


### PR DESCRIPTION
The nginx proxy issue will be addressed with forthcoming kraken PR. This is to remove nodeport and return to using loadbalancer.