### PR TITLE
Use new pause container

### DIFF
--- a/pause/pause.yaml
+++ b/pause/pause.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: pause
-          image: gcr.io/google_containers/pause:go
+          image: gcr.io/google_containers/pause:2.0
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 ---


### PR DESCRIPTION
Partially to exercise slack integration, partially because I see 1.2
kubernetes is using this container now