### PR TITLE
Reduce the default number of replicas to 2 and document the privileged

### DIFF
--- a/ranchervm/ranchervm.yaml
+++ b/ranchervm/ranchervm.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: ranchervm-rc
+  name: ranchervm
 spec:
-  replicas: 6
+  replicas: 2
   selector:
     app: ranchervm
   template:
@@ -22,3 +22,5 @@ spec:
             limits:
               cpu: "1024m"
               memory: "1Gi"
+          securityContext:
+              privileged: false


### PR DESCRIPTION
security context attribute.
See http://kubernetes.io/docs/user-guide/pods/#privileged-mode-for-pod-containers
for details.